### PR TITLE
add dark mode

### DIFF
--- a/app/components/channels/channel-avatar.tsx
+++ b/app/components/channels/channel-avatar.tsx
@@ -27,7 +27,7 @@ export default function ChannelAvatar({ channel, children }: Props) {
       ) : null}
 
       <div className="min-w-0 flex-1">
-        <p className="truncate text-sm font-medium text-gray-900">
+        <p className="truncate text-sm font-medium text-gray-900 dark:text-stone-200">
           {channel.title}
         </p>
 

--- a/app/components/channels/channel-item-card.tsx
+++ b/app/components/channels/channel-item-card.tsx
@@ -68,7 +68,7 @@ export default function ChannelItemCard({
         <Card.CardHeader>
           <ChannelAvatar channel={item.channel}>
             <time
-              className="flex-shrink-0 whitespace-nowrap text-sm text-gray-500"
+              className="flex-shrink-0 whitespace-nowrap text-sm text-gray-500 dark:text-neutral-600 dark:divide-neutral-600"
               dateTime={
                 item.pubDate ? new Date(item.pubDate).toISOString() : undefined
               }
@@ -83,8 +83,8 @@ export default function ChannelItemCard({
 
       <a
         className={classNames({
-          "bg-gray-100": hasRead,
-          "bg-white hover:bg-gray-50": !hasRead,
+          "bg-gray-100 dark:bg-neutral-900 dark:hover:bg-neutral-800 dark:opacity-90": hasRead,
+          "bg-white dark:bg-neutral-900 hover:bg-gray-50 dark:hover:bg-neutral-800": !hasRead,
         })}
         href={item.link}
         onClick={handleClick}
@@ -96,8 +96,8 @@ export default function ChannelItemCard({
             <div className="min-w-0 flex-1">
               <p
                 className={classNames("truncate text-sm font-medium", {
-                  "text-gray-600": hasRead,
-                  "text-gray-900": !hasRead,
+                  "text-gray-600 dark:text-neutral-500": hasRead,
+                  "text-gray-900 dark:text-neutral-300": !hasRead,
                 })}
               >
                 {item.title}
@@ -106,7 +106,7 @@ export default function ChannelItemCard({
 
             {showChannelInformation ? null : (
               <time
-                className="flex-shrink-0 whitespace-nowrap text-sm text-gray-500"
+                className="flex-shrink-0 whitespace-nowrap text-sm text-gray-500 dark:text-neutral-700"
                 dateTime={
                   item.pubDate
                     ? new Date(item.pubDate).toISOString()
@@ -122,8 +122,8 @@ export default function ChannelItemCard({
 
           <div
             className={classNames("mt-1 text-sm line-clamp-2", {
-              "text-gray-500": hasRead,
-              "text-gray-600": !hasRead,
+              "text-gray-500 dark:text-neutral-500": hasRead,
+              "text-gray-600 dark:text-neutral-600": !hasRead,
             })}
           >
             {itemDescription}

--- a/app/components/sidebar/sidebar-channel-link.tsx
+++ b/app/components/sidebar/sidebar-channel-link.tsx
@@ -27,10 +27,10 @@ export default function SidebarChannelLink({
     <NavLink
       className={({ isActive }) =>
         classNames(
-          "group flex flex-col rounded-md px-2 py-2 text-sm font-medium",
+          "group flex flex-col rounded-md px-2 py-2 text-sm font-medium mb-2",
           {
-            "bg-gray-100 text-gray-900": isActive,
-            "text-gray-700 hover:bg-gray-50 hover:text-gray-900": !isActive,
+            "bg-gray-100 text-gray-900 dark:text-neutral-200 dark:bg-neutral-700 dark:hover:bg-neutral-600": isActive,
+            "text-gray-700 dark:text-neutral-400 hover:bg-gray-50 hover:text-gray-900 dark:hover:bg-neutral-700 dark:hover:text-neutral-100": !isActive,
           }
         )
       }
@@ -45,8 +45,8 @@ export default function SidebarChannelLink({
               <span
                 className={classNames(
                   {
-                    "bg-white": !hasUpdates && isActive,
-                    "bg-gray-100 text-gray-600 group-hover:bg-gray-200":
+                    "bg-white dark:bg-neutral-600 dark:text-neutral-300": !hasUpdates && isActive,
+                    "bg-gray-100 dark:bg-neutral-600 text-gray-600 dark:text-neutral-300 group-hover:bg-gray-200 dark:group-hover:bg-neutral-500":
                       !hasUpdates && !isActive,
                     "bg-red-100 text-red-800 group-hover:bg-red-200":
                       hasUpdates && !isActive,
@@ -60,7 +60,7 @@ export default function SidebarChannelLink({
             ) : null}
           </div>
 
-          <p className="truncate text-sm text-gray-500">
+          <p className="truncate text-sm text-gray-500 dark:text-neutral-500">
             {channel.description}
           </p>
         </>

--- a/app/components/sidebar/sidebar-folder-link.tsx
+++ b/app/components/sidebar/sidebar-folder-link.tsx
@@ -13,10 +13,10 @@ export default function SidebarFolderLink({ children, to }: Props) {
       to={to}
       className={({ isActive }) =>
         classNames(
-          "group flex items-center rounded-md px-2 py-2 text-sm font-medium text-gray-600 hover:bg-gray-50 hover:text-gray-900",
+          "group flex items-center rounded-md px-2 py-2 text-sm font-medium text-gray-600 dark:text-neutral-500 dark:divide-neutral-600 hover:bg-gray-50 dark:hover:bg-neutral-600 hover:text-gray-900 dark:hover:text-neutral-100",
           {
-            "bg-gray-100 text-gray-900": isActive,
-            "text-gray-700 hover:bg-gray-50 hover:text-gray-900": !isActive,
+            "bg-gray-100 text-gray-900 dark:text-neutral-200 dark:bg-neutral-700": isActive,
+            "text-gray-700 hover:bg-gray-50 hover:text-gray-900 dark:hover:bg-neutral-700 dark:hover:text-neutral-100": !isActive,
           }
         )
       }

--- a/app/components/sidebar/sidebar-navigation.tsx
+++ b/app/components/sidebar/sidebar-navigation.tsx
@@ -25,7 +25,7 @@ export default function SidebarNavigation({ channels, user }: Props) {
     <div className="flex min-h-0 flex-1 flex-col border-r border-gray-200 dark:border-stone-800 bg-white dark:bg-neutral-900">
       <div className="flex flex-1 flex-col overflow-y-auto pt-5 pb-4">
         <div className="flex flex-shrink-0 items-center space-x-2 border-b border-gray-200 dark:border-stone-800 px-4 pb-4">
-          <Rss color="black" size={32} weight="bold" />
+          <Rss className="text-black dark:text-orange-300" size={32} weight="bold" />
 
           <span className="text-3xl font-bold dark:text-white">RSS Power</span>
         </div>
@@ -89,7 +89,7 @@ export default function SidebarNavigation({ channels, user }: Props) {
         <div className="block w-full flex-shrink-0">
           <div className="flex items-center">
             <div>
-              <UserIcon size={32} />
+              <UserIcon className="dark:text-slate-50" size={32} />
             </div>
 
             <div className="ml-3">

--- a/app/components/sidebar/sidebar-navigation.tsx
+++ b/app/components/sidebar/sidebar-navigation.tsx
@@ -22,12 +22,12 @@ type Props = {
 
 export default function SidebarNavigation({ channels, user }: Props) {
   return (
-    <div className="flex min-h-0 flex-1 flex-col border-r border-gray-200 bg-white">
+    <div className="flex min-h-0 flex-1 flex-col border-r border-gray-200 dark:border-stone-800 bg-white dark:bg-neutral-900">
       <div className="flex flex-1 flex-col overflow-y-auto pt-5 pb-4">
-        <div className="flex flex-shrink-0 items-center space-x-2 border-b border-gray-200 px-4 pb-4">
+        <div className="flex flex-shrink-0 items-center space-x-2 border-b border-gray-200 dark:border-stone-800 px-4 pb-4">
           <Rss color="black" size={32} weight="bold" />
 
-          <span className="text-3xl font-bold">RSS Power</span>
+          <span className="text-3xl font-bold dark:text-white">RSS Power</span>
         </div>
 
         <nav className="flex-1 space-y-6">
@@ -85,7 +85,7 @@ export default function SidebarNavigation({ channels, user }: Props) {
         </div>
       </div>
 
-      <div className="flex flex-shrink-0 border-t border-gray-200 p-4">
+      <div className="flex flex-shrink-0 border-t border-gray-200 dark:border-stone-800 p-4">
         <div className="block w-full flex-shrink-0">
           <div className="flex items-center">
             <div>

--- a/app/components/ui/cards/card.tsx
+++ b/app/components/ui/cards/card.tsx
@@ -14,10 +14,10 @@ function Card({ children, isInactive = false }: CardProps) {
     <CardContext.Provider value={{ isInactive }}>
       <div
         className={classNames(
-          "flex flex-col divide-y divide-gray-200 overflow-hidden rounded-lg shadow",
+          "flex flex-col divide-y divide-gray-200 dark:divide-neutral-700 overflow-hidden rounded-lg shadow",
           {
-            "bg-gray-100": isInactive,
-            "bg-white ": !isInactive,
+            "bg-gray-100 dark:bg-neutral-800 dark:opacity-90": isInactive,
+            "bg-white dark:bg-neutral-800": !isInactive,
           }
         )}
       >
@@ -53,8 +53,8 @@ function CardFooter({ children }: CardFooterProps) {
   return (
     <div
       className={classNames("py-2 px-4 sm:px-6", {
-        "bg-gray-100": isInactive,
-        "bg-gray-50": !isInactive,
+        "bg-gray-100 dark:bg-neutral-900 dark:opacity-90": isInactive,
+        "bg-gray-50 dark:bg-neutral-800": !isInactive,
       })}
     >
       {children}

--- a/app/components/ui/text-button.tsx
+++ b/app/components/ui/text-button.tsx
@@ -23,9 +23,9 @@ export default function TextButton({
   return (
     <button
       className={classNames(
-        "flex items-center space-x-2 rounded py-2 px-4 text-sm text-gray-600",
+        "flex items-center space-x-2 rounded py-2 px-4 text-sm text-gray-600 dark:text-blue-400",
         {
-          "underline hover:text-gray-800": !disabled && !isLoading,
+          "underline hover:text-gray-800 dark:hover:text-neutral-50": !disabled && !isLoading,
           "animate-pulse": isLoading,
         }
       )}

--- a/app/components/ui/typography/page-header.tsx
+++ b/app/components/ui/typography/page-header.tsx
@@ -4,6 +4,6 @@ type Props = {
 
 export default function PageHeader({ children }: Props) {
   return (
-    <h3 className="text-lg font-medium leading-6 text-gray-900">{children}</h3>
+    <h3 className="text-lg font-medium leading-6 text-gray-900 dark:text-neutral-300">{children}</h3>
   );
 }

--- a/app/components/ui/typography/section-header.tsx
+++ b/app/components/ui/typography/section-header.tsx
@@ -4,7 +4,7 @@ type Props = {
 
 export default function SectionHeader({ children }: Props) {
   return (
-    <p className="text-xs font-semibold uppercase tracking-wider text-gray-500">
+    <p className="text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-neutral-500">
       {children}
     </p>
   );

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -38,7 +38,7 @@ export const loader: LoaderFunction = async ({ request }) => {
 
 export default function App() {
   return (
-    <html className="h-full bg-gray-100" lang="en">
+    <html className="h-full bg-gray-100 dark:bg-black" lang="en">
       <head>
         <Meta />
 

--- a/app/routes/feeds/$channelId.tsx
+++ b/app/routes/feeds/$channelId.tsx
@@ -75,7 +75,7 @@ export default function ChannelDetailsPage() {
 
   return (
     <div>
-      <div className="mb-5 border-b border-gray-200 pb-5">
+      <div className="mb-5 border-b border-gray-200 dark:border-neutral-800 pb-5">
         <div className="flex items-center justify-between">
           <div className="flex items-center space-x-2">
             {data.channel.image ? (
@@ -115,7 +115,7 @@ export default function ChannelDetailsPage() {
           </Form>
         </div>
 
-        <p className="mt-2 max-w-4xl text-sm text-gray-600">
+        <p className="mt-2 max-w-4xl text-sm text-gray-600 dark:text-neutral-600">
           {data.channel.description}
         </p>
       </div>

--- a/app/routes/feeds/inbox.tsx
+++ b/app/routes/feeds/inbox.tsx
@@ -52,16 +52,16 @@ export default function InboxPage() {
 
   return (
     <div>
-      <div className="mb-5 border-b border-gray-200 pb-5">
+      <div className="mb-5 border-b border-gray-200 dark:border-neutral-800 pb-5">
         <div className="flex items-center justify-between">
           <div className="flex items-center space-x-2">
-            <Tray className="h-5 w-5 text-gray-900" weight="bold" />
+            <Tray className="h-5 w-5 text-gray-900 dark:text-neutral-300" weight="bold" />
 
             <PageHeader>Inbox</PageHeader>
           </div>
         </div>
 
-        <p className="mt-2 max-w-4xl text-sm text-gray-600">
+        <p className="mt-2 max-w-4xl text-sm text-gray-600 dark:text-neutral-600">
           One place for all your unread feeds
         </p>
       </div>

--- a/app/routes/feeds/new.tsx
+++ b/app/routes/feeds/new.tsx
@@ -143,7 +143,7 @@ export default function NewFeedPage() {
             <Card.CardBody>
               <div>
                 <label
-                  className="block text-sm font-medium text-gray-700"
+                  className="block text-sm font-medium text-gray-700 dark:text-neutral-500"
                   htmlFor="origin"
                 >
                   Feed url
@@ -160,7 +160,7 @@ export default function NewFeedPage() {
                       actionData?.errors?.origin ? "url-error" : undefined
                     }
                     autoFocus
-                    className="block w-full rounded-md border-gray-300 pl-10 focus:border-blue-500 focus:ring-blue-600 sm:text-sm"
+                    className="dark:bg-neutral-500 dark:text-neutral-50 dark:placeholder-neutral-400 block w-full rounded-md border-gray-300 pl-10 focus:border-blue-500 focus:ring-blue-600 sm:text-sm"
                     id="origin"
                     name="origin"
                     placeholder="https://example.com/feed"

--- a/app/routes/feeds/read-later.tsx
+++ b/app/routes/feeds/read-later.tsx
@@ -57,16 +57,16 @@ export default function ReadLaterPage() {
 
   return (
     <div>
-      <div className="mb-5 border-b border-gray-200 pb-5">
+      <div className="mb-5 border-b border-gray-200 dark:border-neutral-800 pb-5">
         <div className="flex items-center justify-between">
           <div className="flex items-center space-x-2">
-            <BookmarkSimple className="h-5 w-5 text-gray-900" weight="bold" />
+            <BookmarkSimple className="h-5 w-5 text-gray-900 dark:text-neutral-600" weight="bold" />
 
             <PageHeader>Read later</PageHeader>
           </div>
         </div>
 
-        <p className="mt-2 max-w-4xl text-sm text-gray-600">
+        <p className="mt-2 max-w-4xl text-sm text-gray-600 dark:text-neutral-600">
           Articles you've marked as read later
         </p>
       </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,5 +3,6 @@ module.exports = {
   theme: {
     extend: {},
   },
+//  darkMode: 'class',
   plugins: [require("@tailwindcss/forms"), require("@tailwindcss/line-clamp")],
 };


### PR DESCRIPTION
First draft on dark-mode. Using the `dark:` class to alter the colours based on the user's `prefers-color-scheme`.

If we would implement a dark-mode toggle, we can update `tailwind.config.js` to:
```js
module.exports = {
// ...
  darkMode: 'class',
}
```

Which will toggle the dark mode only of the element has `dark` class.

#37